### PR TITLE
本体のフォントを游ゴシック、ヒラギノ角ゴシックにした

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,3 +1,8 @@
+/* Font Change */
+body{
+font-family: "Yu Gothic","Hiragino Sans";
+}
+
 .container {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
本体のフォントをWindowsからは游ゴシック（Yu Gothic）、Macからはヒラギノ角ゴシック（Hiragino Sans）に見えるように変更しました