### PR TITLE
フォルダー化出来なかったため、androidを削除

### DIFF
--- a/src/android
+++ b/src/android
@@ -1,1 +1,0 @@
-android.txt


### PR DESCRIPTION
フォルダー化出来なかったため、androidを削除しました。